### PR TITLE
Refresh: modernize targets/deps, fix correctness bugs, deprecate misleading APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (Release, both target frameworks)
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish NuGet
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 10.0.1)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Determine version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            V="${{ github.event.inputs.version }}"
+          else
+            V="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $V"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+      - name: Pack
+        run: dotnet pack Extensions.Standard/Extensions.Standard.csproj --configuration Release --output ./artifacts -p:Version=${{ steps.ver.outputs.version }}
+
+      - name: Push to NuGet
+        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Extensions.Standard.Test/Extensions.Standard.Test.csproj
+++ b/Extensions.Standard.Test/Extensions.Standard.Test.csproj
@@ -1,14 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>net6.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -16,10 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Extensions.Standard\Extensions.Standard.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/Extensions.Standard.Test/ExtensionsTest.cs
+++ b/Extensions.Standard.Test/ExtensionsTest.cs
@@ -17,7 +17,6 @@ namespace Extensions.Standard.Test
         [InlineData(123)]
         [InlineData(99999)]
         [InlineData(0)]
-        [InlineData(-0)]
         [InlineData(-1)]
         [InlineData(-2)]
         [InlineData(-123)]
@@ -844,8 +843,8 @@ namespace Extensions.Standard.Test
             var result = blahblah.Partition(ratio);
             Assert.Single(result[0]);
             Assert.Single(result[1]);
-            Assert.Equal(result[0].First(), item1);
-            Assert.Equal(result[1].First(), item2);
+            Assert.Equal(item1, result[0].First());
+            Assert.Equal(item2, result[1].First());
         }
 
         [Fact]
@@ -860,9 +859,9 @@ namespace Extensions.Standard.Test
             var result = blahblah.Partition(ratio);
             Assert.Equal(2, result[0].Count);
             Assert.Single(result[1]);
-            Assert.Equal(result[0][0], item1);
-            Assert.Equal(result[0][1], item2);
-            Assert.Equal(result[1][0], item3);
+            Assert.Equal(item1, result[0][0]);
+            Assert.Equal(item2, result[0][1]);
+            Assert.Equal(item3, result[1][0]);
         }
 
         [Fact]
@@ -965,7 +964,9 @@ namespace Extensions.Standard.Test
 
         private class PoCo
         {
+#pragma warning disable CS0414 // present only to assert private fields are excluded from the result
             private string test = "DoNotShowThis";
+#pragma warning restore CS0414
             private string test2 { get; set; } = "DoNotShowThis";
             public int TestInt { get; } = 10;
             public string TestString { get; set; } = "20";
@@ -1090,6 +1091,67 @@ namespace Extensions.Standard.Test
             // Assert
             Assert.Null(copy);
         }
+
+        [Fact]
+        public void IsEquivalentDetectsMismatchNotOnlyInLastElement()
+        {
+            // Regression: a non-final differing element used to be ignored.
+            Assert.False(new[] { "3", "1", "2" }.IsEquivalent(new[] { "4", "1", "2" }));
+        }
+
+        [Theory]
+        [InlineData(new[] { "a", "a", "b" }, new[] { "b", "a", "a" }, true)]
+        [InlineData(new[] { "a", "a", "b" }, new[] { "a", "b", "b" }, false)]
+        [InlineData(new[] { "1", "2", "3" }, new[] { "1", "2", "3", "3" }, false)]
+        public void IsEquivalentRespectsMultiplicity(IEnumerable<string> lhs, IEnumerable<string> rhs, bool expected)
+        {
+            Assert.Equal(expected, lhs.IsEquivalent(rhs));
+        }
+
+        [Fact]
+        public void AsMemoryFormatsHighBinaryOrders()
+        {
+            Assert.Equal("1 " + Constants.TebibyteSuffix, Constants.TiB.AsMemory());
+            Assert.Equal("1 " + Constants.PebibyteSuffix, Constants.PiB.AsMemory());
+            Assert.Equal("1 " + Constants.ExbibyteSuffix, Constants.EiB.AsMemory());
+            Assert.Equal("1 " + Constants.ZebibyteSuffix, Constants.ZiB.AsMemory());
+            Assert.Equal("1 " + Constants.YobibyteSuffix, Constants.YiB.AsMemory());
+        }
+
+        [Fact]
+        public void AsMemoryDecimalFormatsHighDecimalOrders()
+        {
+            Assert.Equal("1 " + Constants.TerabyteSuffix, Constants.Tera.AsMemoryDecimal());
+            Assert.Equal("1 " + Constants.PetabyteSuffix, Constants.Peta.AsMemoryDecimal());
+            Assert.Equal("1 " + Constants.ExabyteSuffix, Constants.Exa.AsMemoryDecimal());
+            Assert.Equal("1 " + Constants.ZettabyteSuffix, Constants.Zetta.AsMemoryDecimal());
+            Assert.Equal("1 " + Constants.YottabyteSuffix, Constants.Yotta.AsMemoryDecimal());
+        }
+
+        [Fact]
+        public void ScaleGenericNonDoubleSequenceScalesWithoutThrowing()
+        {
+            // Regression: Cast<double>() on boxed ints threw InvalidCastException.
+            var received = new[] { 0, 5, 10 }.Scale((0.0, 1.0)).ToList();
+            Assert.Equal(0.0, received[0], Precision);
+            Assert.Equal(0.5, received[1], Precision);
+            Assert.Equal(1.0, received[2], Precision);
+        }
+
+        [Theory]
+        [InlineData(10, 20, 30, 255)]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(255, 255, 255, 255)]
+        [InlineData(1, 2, 3, 4)]
+        public void AsColorRoundTripsThroughArgb(byte red, byte green, byte blue, byte alpha)
+        {
+            var unpacked = Utilities.AsColor(red, green, blue, alpha).AsColor();
+            Assert.Equal(alpha, unpacked[0]);
+            Assert.Equal(red, unpacked[1]);
+            Assert.Equal(green, unpacked[2]);
+            Assert.Equal(blue, unpacked[3]);
+        }
+
         #region Unit test related
 
         private class TestClass

--- a/Extensions.Standard.Test/ExtensionsTest.cs
+++ b/Extensions.Standard.Test/ExtensionsTest.cs
@@ -269,6 +269,9 @@ namespace Extensions.Standard.Test
             Assert.Equal(Math.Round(max, Precision), Math.Round(received, Precision));
         }
 
+        // The following tests exercise the deprecated InClosedRange/InOpenRange shims
+        // to verify their (misleading but unchanged) behavior is preserved for consumers.
+#pragma warning disable CS0618
         [Fact]
         public void InOpenRangeTest()
         {
@@ -346,6 +349,7 @@ namespace Extensions.Standard.Test
             Assert.False(123123.InClosedRange(rangeMin, rangeMax));
             Assert.False((-123).InClosedRange(rangeMin, rangeMax));
         }
+#pragma warning restore CS0618
 
         [Fact]
         public void MaxIndexFindsIndexOfBiggestElement()
@@ -613,12 +617,12 @@ namespace Extensions.Standard.Test
         public void LineConstruction()
         {
             var start = new double[] { 0, 0 };
-            var testedLine = Utilities.ConstructLine(start, 10, 0);
+            var testedLine = Utilities.ConstructLineFromRadians(start, 10, 0);
 
             Assert.True(testedLine[0] == 0 && testedLine[1] == 0 && testedLine[2] == 10 && testedLine[3] == 0,
                 $"wrong points: ({testedLine[0]},{testedLine[1]} {testedLine[2]},{testedLine[3]}), should be (0,0 10,0)");
 
-            testedLine = Utilities.ConstructLine(start, 10, 45);
+            testedLine = Utilities.ConstructLineFromRadians(start, 10, 45);
 
             Assert.True(testedLine[0] == 0 && testedLine[1] == 0 && testedLine[2] > 5.253 && testedLine[2] < 5.254 && testedLine[3] > 8.509 && testedLine[3] < 8.51,
                 $"wrong points: ({testedLine[0]},{testedLine[1]} {testedLine[2]},{testedLine[3]}), should be (0,0 5.253,8.509)");
@@ -1150,6 +1154,49 @@ namespace Extensions.Standard.Test
             Assert.Equal(red, unpacked[1]);
             Assert.Equal(green, unpacked[2]);
             Assert.Equal(blue, unpacked[3]);
+        }
+
+        [Fact]
+        public void InRangeInclusiveIncludesEndpoints()
+        {
+            Assert.True(0.InRangeInclusive(0, 10));
+            Assert.True(10.InRangeInclusive(0, 10));
+            Assert.True(5.InRangeInclusive(0, 10));
+            Assert.False((-1).InRangeInclusive(0, 10));
+            Assert.False(11.InRangeInclusive(0, 10));
+        }
+
+        [Fact]
+        public void InRangeExclusiveExcludesEndpoints()
+        {
+            Assert.False(0.InRangeExclusive(0, 10));
+            Assert.False(10.InRangeExclusive(0, 10));
+            Assert.True(5.InRangeExclusive(0, 10));
+            Assert.False((-1).InRangeExclusive(0, 10));
+            Assert.False(11.InRangeExclusive(0, 10));
+        }
+
+        [Fact]
+        public void ConstructLineFromDegreesConvertsAngle()
+        {
+            var start = new double[] { 0, 0 };
+            var line = Utilities.ConstructLineFromDegrees(start, 10, 45);
+
+            Assert.Equal(0, line[0]);
+            Assert.Equal(0, line[1]);
+            Assert.True(line[2] > 7.07 && line[2] < 7.072, $"x2 was {line[2]}, expected ~7.071");
+            Assert.True(line[3] > 7.07 && line[3] < 7.072, $"y2 was {line[3]}, expected ~7.071");
+        }
+
+        [Fact]
+        public void ObsoleteConstructLineStillBehavesLikeRadiansVariant()
+        {
+            var start = new double[] { 0, 0 };
+#pragma warning disable CS0618
+            var legacy = Utilities.ConstructLine(start, 10, 1.2);
+#pragma warning restore CS0618
+            var current = Utilities.ConstructLineFromRadians(start, 10, 1.2);
+            Assert.Equal(current, legacy);
         }
 
         #region Unit test related

--- a/Extensions.Standard/Extensions.Standard.csproj
+++ b/Extensions.Standard/Extensions.Standard.csproj
@@ -24,7 +24,7 @@ Suffixes (AsMemory, AsTime), Interpolate, Partition, Shuffle (O(n)), Softmax, In
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StandardInterfaces" Version="3.1.0" />
   </ItemGroup>
 

--- a/Extensions.Standard/Extensions.Standard.csproj
+++ b/Extensions.Standard/Extensions.Standard.csproj
@@ -17,8 +17,8 @@ Suffixes (AsMemory, AsTime), Interpolate, Partition, Shuffle (O(n)), Softmax, In
     <RepositoryUrl>https://github.com/PFalkowski/Extensions.Standard</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>extensions, extension-methods, netcore, netstandard, boilerplate</PackageTags>
-    <Version>9.2.0</Version>
-    <PackageReleaseNotes>Multi-target netstandard2.0 and net8.0. Fixed IsEquivalent, AsMemory/AsMemoryDecimal high orders, generic Scale, and AsColor packing.</PackageReleaseNotes>
+    <Version>10.0.0</Version>
+    <PackageReleaseNotes>Multi-target netstandard2.0 and net8.0. Fixed IsEquivalent, AsMemory/AsMemoryDecimal high orders, generic Scale, and AsColor packing. Deprecated InClosedRange/InOpenRange (misleading names) in favor of InRangeInclusive/InRangeExclusive, and ConstructLine in favor of ConstructLineFromRadians/ConstructLineFromDegrees.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Extensions.Standard/Extensions.Standard.csproj
+++ b/Extensions.Standard/Extensions.Standard.csproj
@@ -1,26 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Ship XML docs for documented members without requiring every public member to be documented. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Description>Lightweight extensions methods (and constants) for common programming tasks:
 
 Suffixes (AsMemory, AsTime), Interpolate, Partition, Shuffle (O(n)), Softmax, InnerProduct, IsPrime, ManhattanDistance, EuclideanDistance, InClosedRange, MeanSquaredError, EqualsWithTolerance, HsVtoArgb, Scale, Fit and many more.</Description>
     <Company>Piotr Falkowski</Company>
     <Authors>Piotr Falkowski</Authors>
-    <Copyright>Piotr Falkowski © 2024</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/PFalkowski/Extensions.Standard</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/Extensions.Standard</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>extensions, extension-methods, netcore, netstandard, boilerplate</PackageTags>
-    <Version>9.1.0</Version>
-    <PackageReleaseNotes>Add DeepCopy</PackageReleaseNotes>
+    <Version>9.2.0</Version>
+    <PackageReleaseNotes>Multi-target netstandard2.0 and net8.0. Fixed IsEquivalent, AsMemory/AsMemoryDecimal high orders, generic Scale, and AsColor packing.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;RELEASE;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Extensions.Standard/Extensions.Standard.csproj
+++ b/Extensions.Standard/Extensions.Standard.csproj
@@ -17,10 +17,15 @@ Suffixes (AsMemory, AsTime), Interpolate, Partition, Shuffle (O(n)), Softmax, In
     <RepositoryUrl>https://github.com/PFalkowski/Extensions.Standard</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>extensions, extension-methods, netcore, netstandard, boilerplate</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>10.0.0</Version>
     <PackageReleaseNotes>Multi-target netstandard2.0 and net8.0. Fixed IsEquivalent, AsMemory/AsMemoryDecimal high orders, generic Scale, and AsColor packing. Deprecated InClosedRange/InOpenRange (misleading names) in favor of InRangeInclusive/InRangeExclusive, and ConstructLine in favor of ConstructLineFromRadians/ConstructLineFromDegrees.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Extensions.Standard/Utilities.cs
+++ b/Extensions.Standard/Utilities.cs
@@ -48,15 +48,32 @@ namespace Extensions.Standard
             return degrees / (180.0 / Math.PI);
         }
 
-        public static double[] ConstructLine(double[] startingPointXy, double length, double angleDegrees)
+        /// <summary>
+        ///     Constructs a line segment [x1, y1, x2, y2] from a starting point, length and angle in radians.
+        /// </summary>
+        public static double[] ConstructLineFromRadians(double[] startingPointXy, double length, double angleRadians)
         {
             return new[]
             {
                 startingPointXy[0],
                 startingPointXy[1],
-                startingPointXy[0] + length * Math.Cos(angleDegrees),
-                startingPointXy[1] + length * Math.Sin(angleDegrees)
+                startingPointXy[0] + length * Math.Cos(angleRadians),
+                startingPointXy[1] + length * Math.Sin(angleRadians)
             };
+        }
+
+        /// <summary>
+        ///     Constructs a line segment [x1, y1, x2, y2] from a starting point, length and angle in degrees.
+        /// </summary>
+        public static double[] ConstructLineFromDegrees(double[] startingPointXy, double length, double angleDegrees)
+        {
+            return ConstructLineFromRadians(startingPointXy, length, angleDegrees.ToRadians());
+        }
+
+        [Obsolete("The angle is interpreted as radians despite the parameter name. Use ConstructLineFromRadians (identical behavior) or ConstructLineFromDegrees. Will be removed in a future major version.")]
+        public static double[] ConstructLine(double[] startingPointXy, double length, double angleDegrees)
+        {
+            return ConstructLineFromRadians(startingPointXy, length, angleDegrees);
         }
 
         public static double Interpolate(double[] p1, double[] p2, double x)
@@ -85,11 +102,29 @@ namespace Extensions.Standard
 
         #region Distance Measures
 
+        /// <summary>
+        ///     Returns true when <paramref name="value"/> lies within the closed interval [from, to] (endpoints included).
+        /// </summary>
+        public static bool InRangeInclusive<T>(this T value, T from, T to) where T : IComparable<T>
+        {
+            return value.CompareTo(@from) >= 0 && value.CompareTo(to) <= 0;
+        }
+
+        /// <summary>
+        ///     Returns true when <paramref name="value"/> lies within the open interval (from, to) (endpoints excluded).
+        /// </summary>
+        public static bool InRangeExclusive<T>(this T value, T from, T to) where T : IComparable<T>
+        {
+            return value.CompareTo(@from) > 0 && value.CompareTo(to) < 0;
+        }
+
+        [Obsolete("Misleading name: this excludes the endpoints (open interval). Use InRangeExclusive instead. Will be removed in a future major version.")]
         public static bool InClosedRange<T>(this T value, T from, T to) where T : IComparable<T>
         {
             return value.CompareTo(@from) > 0 && value.CompareTo(to) < 0;
         }
 
+        [Obsolete("Misleading name: this includes the endpoints (closed interval). Use InRangeInclusive instead. Will be removed in a future major version.")]
         public static bool InOpenRange<T>(this T value, T from, T to) where T : IComparable<T>
         {
             return value.CompareTo(@from) >= 0 && value.CompareTo(to) <= 0;
@@ -723,7 +758,7 @@ namespace Extensions.Standard
         {
             if (scale.Min > scale.Max) throw new ArgumentOutOfRangeException(nameof(scale.Min));
             var tmp = value * (scale.Max - scale.Min);
-            if (double.IsInfinity(tmp) && value.InClosedRange(0.0, 1.0))
+            if (double.IsInfinity(tmp) && value.InRangeExclusive(0.0, 1.0))
             {
                 return value.ScaleSafe(scale.Min, scale.Max);
             }

--- a/Extensions.Standard/Utilities.cs
+++ b/Extensions.Standard/Utilities.cs
@@ -210,6 +210,13 @@ namespace Extensions.Standard
             return result;
         }
 
+#if NET6_0_OR_GREATER
+        private static Random SharedRandom => Random.Shared;
+#else
+        [ThreadStatic] private static Random _threadStaticRandom;
+        private static Random SharedRandom => _threadStaticRandom ??= new Random();
+#endif
+
         /// <summary>
         ///     Performs in-place Knuth Shuffle - reorder items randomly in-place, with Fisher-Yates algorithm.
         ///     O(n) complexity. see: http://rosettacode.org/wiki/Knuth_shuffle#C.23
@@ -220,7 +227,7 @@ namespace Extensions.Standard
         /// <returns></returns>
         public static void Shuffle<T>(this IList<T> input, Random rand = null)
         {
-            rand ??= Random.Shared;
+            rand ??= SharedRandom;
             for (var i = 0; i < input.Count; ++i)
             {
                 var j = rand.Next(i, input.Count);
@@ -323,30 +330,36 @@ namespace Extensions.Standard
         /// <returns></returns>
         public static bool IsEquivalent<T>(this IEnumerable<T> collectionLhs, IEnumerable<T> collectionRhs)
         {
-            var result = true;
-            if (collectionLhs == null && collectionRhs == null)
+            if (collectionLhs == null && collectionRhs == null) return true;
+            if (collectionLhs == null || collectionRhs == null) return false;
+
+            // Multiset (bag) equality: same elements with the same multiplicity, order independent.
+            var counts = new Dictionary<T, int>();
+            var nullCount = 0;
+            foreach (var item in collectionLhs)
             {
-                return true;
+                if (item == null) { ++nullCount; continue; }
+                counts.TryGetValue(item, out var current);
+                counts[item] = current + 1;
             }
 
-            if (collectionLhs == null || collectionRhs == null)
+            foreach (var item in collectionRhs)
             {
-                return false;
-            }
-            var listA = collectionLhs as IList<T> ?? collectionLhs.ToList();
-            var listB = collectionRhs as HashSet<T> ?? collectionRhs.ToHashSet();
-
-            if (listA.Count != listB.Count)
-            {
-                return false;
-            }
-
-            foreach (var listAItem in listA)
-            {
-                result = listB.Contains(listAItem);
+                if (item == null)
+                {
+                    if (--nullCount < 0) return false;
+                    continue;
+                }
+                if (!counts.TryGetValue(item, out var current) || current == 0) return false;
+                counts[item] = current - 1;
             }
 
-            return result;
+            if (nullCount != 0) return false;
+            foreach (var remaining in counts.Values)
+            {
+                if (remaining != 0) return false;
+            }
+            return true;
         }
 
         /// <summary>
@@ -381,7 +394,7 @@ namespace Extensions.Standard
 
             var stb = new StringBuilder();
             stb.AppendLine();
-            stb.AppendJoin(Environment.NewLine, input.Take(n));
+            stb.Append(string.Join(Environment.NewLine, input.Take(n)));
             stb.AppendLine();
             stb.AppendLine("...");
             stb.AppendLine();
@@ -401,7 +414,7 @@ namespace Extensions.Standard
             var stb = new StringBuilder();
             stb.AppendLine();
             stb.AppendLine("...");
-            stb.AppendJoin(Environment.NewLine, input.Skip(input.Count - n));
+            stb.Append(string.Join(Environment.NewLine, input.Skip(input.Count - n)));
             stb.AppendLine();
 
             return stb.ToString();
@@ -419,10 +432,10 @@ namespace Extensions.Standard
 
             var stb = new StringBuilder();
             stb.AppendLine();
-            stb.AppendJoin(Environment.NewLine, input.Take(n));
+            stb.Append(string.Join(Environment.NewLine, input.Take(n)));
             stb.AppendLine();
             stb.AppendLine("...");
-            stb.AppendJoin(Environment.NewLine, input.Skip(input.Count - n));
+            stb.Append(string.Join(Environment.NewLine, input.Skip(input.Count - n)));
             stb.AppendLine();
 
             return stb.ToString();
@@ -449,7 +462,7 @@ namespace Extensions.Standard
         /// <returns></returns>
         public static int AsColor(byte red, byte green, byte blue, byte alpha = 255)
         {
-            return alpha + (red << 8) + (green << 16) + (blue << 24);
+            return (alpha << 24) | (red << 16) | (green << 8) | blue;
         }
 
         /// <summary>
@@ -518,39 +531,7 @@ namespace Extensions.Standard
             CultureInfo culture = null)
             where T : IConvertible
         {
-            var bytesConverted = Convert.ToDecimal(bytes);
-            var numberFormat = (NumberFormatInfo)(culture?.NumberFormat ?? CultureInfo.InvariantCulture.NumberFormat).Clone();
-            if (numberSeparator != null) numberFormat.NumberGroupSeparator = numberSeparator;
-
-            if (bytesConverted < Constants.KiB)
-            {
-                return $"{bytesConverted.ToString(numberFormat)} {"byte".PluralizeWhenNeeded(bytesConverted)}";
-            }
-            if (bytesConverted < Constants.MiB)
-            {
-                return $"{Math.Round(bytesConverted / Constants.KiB, decimals).ToString(numberFormat)} {Constants.KibibyteSuffix}";
-            }
-            if (bytesConverted < Constants.GiB)
-            {
-                return $"{Math.Round(bytesConverted / Constants.MiB, decimals).ToString(numberFormat)} {Constants.MebibyteSuffix}";
-            }
-            if (bytesConverted < Constants.TiB)
-            {
-                return $"{Math.Round(bytesConverted / Constants.GiB, decimals).ToString(numberFormat)} {Constants.GibibyteSuffix}";
-            }
-            if (bytesConverted < Constants.PiB)
-            {
-                return $"{Math.Round(bytesConverted / Constants.TiB, decimals).ToString(numberFormat)} {Constants.TebibyteSuffix}";
-            }
-            if (bytesConverted < Constants.EiB)
-            {
-                return $"{Math.Round(bytesConverted / Constants.PiB, decimals).ToString(numberFormat)} {Constants.PebibyteSuffix}";
-            }
-            if (bytesConverted < Constants.ZiB)
-            {
-                return $"{Math.Round(bytesConverted / Constants.YiB, decimals).ToString(numberFormat)} {Constants.ExbibyteSuffix}";
-            }
-            return $"{Math.Round(bytesConverted / Constants.ZiB, decimals).ToString(numberFormat)} {Constants.YobibyteSuffix}";
+            return FormatMagnitude(Convert.ToDecimal(bytes), Constants.BinaryOrders, decimals, numberSeparator, culture);
         }
 
         /// <summary>
@@ -565,39 +546,33 @@ namespace Extensions.Standard
             CultureInfo culture = null)
             where T : IConvertible
         {
-            var bytesConverted = Convert.ToDecimal(bytes);
+            return FormatMagnitude(Convert.ToDecimal(bytes), Constants.DecimalOrders, decimals, numberSeparator, culture);
+        }
+
+        /// <summary>
+        ///     Renders <paramref name="value"/> using the largest order of magnitude in <paramref name="orders"/>
+        ///     that does not exceed it. The first entry in <paramref name="orders"/> is treated as the base unit
+        ///     ("byte") and is pluralized rather than scaled.
+        /// </summary>
+        private static string FormatMagnitude(decimal value, Tuple<string, decimal>[] orders, byte decimals,
+            string numberSeparator, CultureInfo culture)
+        {
             var numberFormat = (NumberFormatInfo)(culture?.NumberFormat ?? CultureInfo.InvariantCulture.NumberFormat).Clone();
             if (numberSeparator != null) numberFormat.NumberGroupSeparator = numberSeparator;
 
-            if (bytesConverted < Constants.Kilo)
+            var orderIndex = 0;
+            for (var i = 1; i < orders.Length; ++i)
             {
-                return $"{bytesConverted.ToString(numberFormat)} {"byte".PluralizeWhenNeeded(bytesConverted)}";
+                if (value < orders[i].Item2) break;
+                orderIndex = i;
             }
-            if (bytesConverted < Constants.Mega)
+
+            var (suffix, multiplier) = (orders[orderIndex].Item1, orders[orderIndex].Item2);
+            if (orderIndex == 0)
             {
-                return $"{Math.Round(bytesConverted / Constants.Kilo, decimals).ToString(numberFormat)} {Constants.KilobyteSuffix}";
+                return $"{value.ToString(numberFormat)} {suffix.PluralizeWhenNeeded(value)}";
             }
-            if (bytesConverted < Constants.Giga)
-            {
-                return $"{Math.Round(bytesConverted / Constants.Mega, decimals).ToString(numberFormat)} {Constants.MegabyteSuffix}";
-            }
-            if (bytesConverted < Constants.Tera)
-            {
-                return $"{Math.Round(bytesConverted / Constants.Giga, decimals).ToString(numberFormat)} {Constants.GigabyteSuffix}";
-            }
-            if (bytesConverted < Constants.Peta)
-            {
-                return $"{Math.Round(bytesConverted / Constants.Tera, decimals).ToString(numberFormat)} {Constants.TerabyteSuffix}";
-            }
-            if (bytesConverted < Constants.Exa)
-            {
-                return $"{Math.Round(bytesConverted / Constants.Peta, decimals).ToString(numberFormat)} {Constants.PetabyteSuffix}";
-            }
-            if (bytesConverted < Constants.Zetta)
-            {
-                return $"{Math.Round(bytesConverted / Constants.Exa, decimals).ToString(numberFormat)} {Constants.ZettabyteSuffix}";
-            }
-            return $"{Math.Round(bytesConverted / Constants.Zetta, decimals).ToString(numberFormat)} {Constants.YobibyteSuffix}";
+            return $"{Math.Round(value / multiplier, decimals).ToString(numberFormat)} {suffix}";
         }
 
         /// <summary>
@@ -777,7 +752,7 @@ namespace Extensions.Standard
         public static IEnumerable<double> Scale(this IEnumerable<double> data, (double Min, double Max) scale)
         {
             var enumerated = data as double[] ?? data.ToArray();
-            var (min, max) = data.FindMinMaxInOn();
+            var (min, max) = enumerated.FindMinMaxInOn();
             var m = (scale.Max - scale.Min) / (max - min);
             var c = scale.Min - min * m;
             var result = new double[enumerated.Length];
@@ -797,7 +772,7 @@ namespace Extensions.Standard
         public static IEnumerable<double> Scale<T>(this IEnumerable<T> data, (double Min, double Max) scale) where T : IConvertible
         {
             var enumerated = data as T[] ?? data.ToArray();
-            var (min, max) = enumerated.Cast<double>().FindMinMaxInOn();
+            var (min, max) = enumerated.Select(x => Convert.ToDouble(x)).FindMinMaxInOn();
             var m = (scale.Max - scale.Min) / (max - min);
             var c = scale.Min - min * m;
             var result = new double[enumerated.Length];

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lightweight extensions methods (and constants) for common programming tasks, lik
 - IsPrime
 - ManhattanDistance
 - EuclideanDistance
-- InClosedRange
+- InRangeInclusive / InRangeExclusive
 - MeanSquaredError
 - EqualsWithTolerance
 - HsVtoArgb

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Extensions.Standard
 
+[![CI](https://github.com/PFalkowski/Extensions.Standard/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/Extensions.Standard/actions/workflows/ci.yml)
 [![NuGet version (Extensions.Standard)](https://img.shields.io/nuget/v/Extensions.Standard.svg)](https://www.nuget.org/packages/Extensions.Standard/)
 [![Licence (Extensions.Serialization)](https://img.shields.io/github/license/mashape/apistatus.svg)](https://choosealicense.com/licenses/mit/)
 


### PR DESCRIPTION
Refreshes this long-dormant package: fixes real correctness bugs, modernizes the build, and deprecates two misleadingly-named APIs without breaking existing consumers.

## Correctness fixes (non-breaking)
- **`IsEquivalent`** — was returning only the *last* element's membership and de-duplicating one side via `HashSet`. Now does proper multiset (bag) equality. (Genuinely returned wrong answers, e.g. `{"3","1","2"}` vs `{"4","1","2"}` → `true`.)
- **`AsMemory` / `AsMemoryDecimal`** — wrong divisor/suffix at the exbibyte+ and zettabyte+ tiers. Rewritten to drive off the existing `BinaryOrders`/`DecimalOrders` tables (also removes the duplicated if/else ladders).
- **`Scale<T>`** over non-`double` `IConvertible` — `Cast<double>()` threw `InvalidCastException` on boxed ints; now uses `Convert.ToDouble`.
- **`Scale(IEnumerable<double>)`** — computed min/max off the original source instead of the materialized copy (double-enumerated lazy sequences).
- **`AsColor`** — encoder packed bytes inconsistently with the decoder; now produces a standard ARGB int that round-trips.

## Modernization
- Multi-target **`netstandard2.0;net8.0`** (was EOL `net6.0` only). `LangVersion latest`, ships XML docs. Removed the bogus `NETSTANDARD2_0` `DefineConstants` and deprecated empty `PackageLicenseUrl`.
- netstandard2.0 compatibility: cross-target shared `Random` (`Random.Shared` is net6+), replaced `StringBuilder.AppendJoin` and `Enumerable.ToHashSet`.
- Bumped test deps (Test.Sdk 17.12, xunit 2.9.2, NSubstitute 5.3), test project to net8.0, removed legacy `<Service>` entry.

## Deprecations (the only breaking-ish part — handled via `[Obsolete]` shims)
- `InClosedRange`/`InOpenRange` had **inverted** semantics → added **`InRangeInclusive`** / **`InRangeExclusive`**; old names kept as `[Obsolete]` with unchanged behavior.
- `ConstructLine`'s `angleDegrees` was actually radians → added **`ConstructLineFromRadians`** (identical) and **`ConstructLineFromDegrees`**; old method `[Obsolete]`.
- Version bumped to **10.0.0**.

## Tests
178/178 passing, clean build (0 warnings) on both TFMs. Added regression coverage for every fixed bug and the new methods; existing range tests retained as shim coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)