### PR TITLE
Use NuGet Trusted Publishing (OIDC) instead of API key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required to request the GitHub OIDC token for NuGet Trusted Publishing
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,5 +47,11 @@ jobs:
       - name: Pack
         run: dotnet pack Extensions.Standard/Extensions.Standard.csproj --configuration Release --output ./artifacts -p:Version=${{ steps.ver.outputs.version }}
 
+      - name: NuGet auth (Trusted Publishing via OIDC)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       - name: Push to NuGet
-        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "artifacts/*.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
NuGet.org now discourages long-lived API keys in favor of Trusted Publishing. This switches the publish workflow to OIDC.

## Changes
- Grant the publish job `id-token: write` (required to mint the GitHub OIDC token).
- Add a `NuGet/login@v1` step that exchanges the OIDC token for a **short-lived** API key.
- Push using that short-lived key; the `secrets.NUGET_API_KEY` reference is removed entirely.
- The NuGet account name comes from the `NUGET_USER` repo **variable** (not a secret — it's just a username).

## Required setup (one-time)
- Set the repo variable: `gh variable set NUGET_USER --body <your-nuget-username>`
- Ensure the NuGet.org Trusted Publishing policy points at owner `PFalkowski`, repo `Extensions.Standard`, workflow `publish.yml`.
- Any previously-created `NUGET_API_KEY` secret is no longer used and can be deleted.

No long-lived credentials remain in the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)