### PR TITLE
v12.0.0: correctness fixes, test coverage, Codecov + SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,12 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/**/coverage.cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false   # tokenless/public uploads are best-effort; never fail the build on them
+          flags: unittests

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,61 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  sonar:
+    name: Build, test & analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # full history for accurate new-code/blame attribution
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'   # required by the Sonar scanner engine
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install Sonar + coverage tools
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-coverage
+
+      - name: Build, test & analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # If SONAR_TOKEN is not configured yet, skip analysis instead of failing the build.
+        run: |
+          if [ -z "$SONAR_TOKEN" ]; then
+            echo "SONAR_TOKEN secret is not set - skipping SonarCloud analysis."
+            echo "See SONAR_SETUP.md to finish the one-time setup."
+            exit 0
+          fi
+          dotnet sonarscanner begin \
+            /k:"PFalkowski_Extensions.Standard" \
+            /o:"pfalkowski" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.token="${SONAR_TOKEN}" \
+            /d:sonar.cs.vscoveragexml.reportsPaths="coverage.xml"
+          dotnet build --configuration Release
+          dotnet-coverage collect "dotnet test --configuration Release --no-build" -f xml -o coverage.xml
+          dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"

--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+# Coverage output (dotnet test --collect / Codecov)
+coverage/
+**/coverage.cobertura.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [12.0.0] - 2026-06-14
+
+### Changed (breaking)
+- `Area()` now returns a non-negative magnitude. Previously it returned the *signed* shoelace area,
+  which was negative for clockwise-wound polygons. ([#7])
+- `MaxIndex()` and `FindMinMaxInOn()` now throw `InvalidOperationException` on an empty sequence,
+  matching the LINQ `Max()`/`Min()` convention (previously `MaxIndex()` threw
+  `ArgumentOutOfRangeException` from an internal index access and `FindMinMaxInOn()` returned an
+  inverted `(double.MaxValue, double.MinValue)` range). `Scale()` on an empty sequence still returns
+  an empty sequence. ([#9])
+- `AsTime(TimeSpan)` no longer leaves a trailing `", "` separator and now returns `"0 ms"` for
+  `TimeSpan.Zero`, consistent with the `AsTime(milliseconds)` overload. ([#10])
+
+### Removed (breaking)
+- Removed the redundant `Scale<T>(IEnumerable<double>)` overload whose type parameter was never used.
+  Use the non-generic `Scale()` (0..1 normalisation) instead. ([#8])
+
+### Added
+- Black-box test coverage for previously-untested public surface (`HsVtoArgb`, `Head`/`Tail`/
+  `HeadAndTail`, `PluralizeWhenNeeded`, `AsTime(TimeSpan)`, `FindMinMaxInOn`, `Scale()`, `MaxIndex`).
+- Code coverage upload to Codecov from CI, and a SonarCloud analysis workflow (see `SONAR_SETUP.md`).
+
+## [11.0.0]
+
+### Changed (breaking)
+- `DeepCopy` is now a dependency-free, reflection-based deep clone (copies private/inherited fields,
+  preserves shared references and cycles, no `[Serializable]`/parameterless-ctor requirement).
+- Removed the `Newtonsoft.Json` dependency and the `JsonSerializerSettings` overload of `DeepCopy`.
+
+## [10.0.0]
+
+### Changed (breaking)
+- Multi-targeted (`netstandard2.0`, `net8.0`), modernised dependencies, fixed correctness bugs.
+
+### Deprecated
+- `InClosedRange`/`InOpenRange` (inverted semantics — use `InRangeExclusive`/`InRangeInclusive`) and
+  `ConstructLine` (use `ConstructLineFromRadians`/`ConstructLineFromDegrees`).
+
+[12.0.0]: https://github.com/PFalkowski/Extensions.Standard/releases/tag/v12.0.0
+[11.0.0]: https://github.com/PFalkowski/Extensions.Standard/releases/tag/v11.0.0
+[10.0.0]: https://github.com/PFalkowski/Extensions.Standard/releases/tag/v10.0.0
+[#7]: https://github.com/PFalkowski/Extensions.Standard/issues/7
+[#8]: https://github.com/PFalkowski/Extensions.Standard/issues/8
+[#9]: https://github.com/PFalkowski/Extensions.Standard/issues/9
+[#10]: https://github.com/PFalkowski/Extensions.Standard/issues/10

--- a/Extensions.Standard.Test/Extensions.Standard.Test.csproj
+++ b/Extensions.Standard.Test/Extensions.Standard.Test.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/Extensions.Standard.Test/UncoveredPathsTests.cs
+++ b/Extensions.Standard.Test/UncoveredPathsTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Extensions.Standard.Test
+{
+    /// <summary>
+    /// Black-box tests for public surface that had no direct coverage. Expectations are derived from
+    /// each method's name and XML documentation / well-known definitions (e.g. HSV colour theory),
+    /// not from the current implementation.
+    /// </summary>
+    public class UncoveredPathsTests
+    {
+        private const int Precision = 5;
+
+        #region HsVtoArgb (advertised in the package description, previously untested)
+
+        // Reference values from the standard HSV->RGB conversion. Result layout is [A, R, G, B].
+        [Theory]
+        [InlineData(0.0, 0.0, 0.0, 0, 0, 0)]       // black
+        [InlineData(0.0, 0.0, 1.0, 255, 255, 255)] // white
+        [InlineData(0.0, 1.0, 1.0, 255, 0, 0)]     // red
+        [InlineData(120.0, 1.0, 1.0, 0, 255, 0)]   // green
+        [InlineData(240.0, 1.0, 1.0, 0, 0, 255)]   // blue
+        [InlineData(60.0, 1.0, 1.0, 255, 255, 0)]  // yellow
+        [InlineData(180.0, 1.0, 1.0, 0, 255, 255)] // cyan
+        [InlineData(300.0, 1.0, 1.0, 255, 0, 255)] // magenta
+        public void HsVtoArgbConvertsKnownColors(double hue, double saturation, double value,
+            int expectedRed, int expectedGreen, int expectedBlue)
+        {
+            var argb = Utilities.HsVtoArgb(hue, saturation, value);
+
+            Assert.Equal(255, (int)argb[0]); // fully opaque alpha
+            Assert.Equal(expectedRed, (int)argb[1]);
+            Assert.Equal(expectedGreen, (int)argb[2]);
+            Assert.Equal(expectedBlue, (int)argb[3]);
+        }
+
+        [Fact]
+        public void HsVtoArgbHue0AndHue360ProduceSameColor()
+        {
+            var atZero = Utilities.HsVtoArgb(0.0, 1.0, 1.0);
+            var atFull = Utilities.HsVtoArgb(360.0, 1.0, 1.0);
+            Assert.Equal(atZero, atFull);
+        }
+
+        #endregion
+
+        #region Head / Tail / HeadAndTail
+
+        [Fact]
+        public void HeadThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IList<int>)null).Head(1));
+        }
+
+        [Fact]
+        public void TailThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IList<int>)null).Tail(1));
+        }
+
+        [Fact]
+        public void HeadAndTailThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IList<int>)null).HeadAndTail(1));
+        }
+
+        [Fact]
+        public void HeadReturnsEmptyStringForEmptyInput()
+        {
+            Assert.Equal(string.Empty, new List<int>().Head(3));
+            Assert.Equal(string.Empty, new List<int>().Tail(3));
+            Assert.Equal(string.Empty, new List<int>().HeadAndTail(3));
+        }
+
+        [Fact]
+        public void HeadThrowsWhenNExceedsCount()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new List<int> { 1, 2 }.Head(3));
+        }
+
+        [Fact]
+        public void HeadContainsFirstNItemsInOrderFollowedByEllipsis()
+        {
+            var list = new List<string> { "alpha", "beta", "gamma", "delta" };
+
+            var head = list.Head(2);
+
+            Assert.Contains("alpha", head);
+            Assert.Contains("beta", head);
+            Assert.Contains("...", head);
+            Assert.DoesNotContain("gamma", head);
+            Assert.DoesNotContain("delta", head);
+            Assert.True(head.IndexOf("alpha", StringComparison.Ordinal) < head.IndexOf("beta", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void TailContainsLastNItemsFollowedByEllipsis()
+        {
+            var list = new List<string> { "alpha", "beta", "gamma", "delta" };
+
+            var tail = list.Tail(2);
+
+            Assert.Contains("gamma", tail);
+            Assert.Contains("delta", tail);
+            Assert.Contains("...", tail);
+            Assert.DoesNotContain("alpha", tail);
+            Assert.DoesNotContain("beta", tail);
+        }
+
+        [Fact]
+        public void HeadAndTailContainsBothEnds()
+        {
+            var list = new List<string> { "alpha", "beta", "gamma", "delta" };
+
+            var headAndTail = list.HeadAndTail(1);
+
+            Assert.Contains("alpha", headAndTail);
+            Assert.Contains("delta", headAndTail);
+            Assert.Contains("...", headAndTail);
+            Assert.DoesNotContain("beta", headAndTail);
+            Assert.DoesNotContain("gamma", headAndTail);
+        }
+
+        #endregion
+
+        #region PluralizeWhenNeeded
+
+        [Theory]
+        [InlineData(1, "day")]
+        [InlineData(2, "days")]
+        [InlineData(0, "days")]
+        [InlineData(5, "days")]
+        public void PluralizeWhenNeededPluralizesEverythingButOne(int number, string expected)
+        {
+            Assert.Equal(expected, "day".PluralizeWhenNeeded(number));
+        }
+
+        #endregion
+
+        #region AsTime(TimeSpan)
+
+        [Fact]
+        public void AsTimeSpanFormatsAllComponents()
+        {
+            var ts = new TimeSpan(2, 3, 4, 5, 6); // 2 days, 3 h, 4 min, 5 s, 6 ms
+            Assert.Equal("2 days, 3 h, 4 min, 5 s, 6 ms", ts.AsTime());
+        }
+
+        [Fact]
+        public void AsTimeSpanUsesSingularDay()
+        {
+            var ts = new TimeSpan(1, 1, 0, 0, 0); // 1 day, 1 hour
+            Assert.Equal("1 day, 1 h", ts.AsTime());
+        }
+
+        [Fact]
+        public void AsTimeSpanOmitsZeroComponentsAndHasNoTrailingSeparator()
+        {
+            Assert.Equal("5 min", TimeSpan.FromMinutes(5).AsTime());
+        }
+
+        [Fact]
+        public void AsTimeSpanZeroReturnsZeroMilliseconds()
+        {
+            Assert.Equal("0 ms", TimeSpan.Zero.AsTime());
+        }
+
+        #endregion
+
+        #region AsTime<T> singular-day branch (previously only the plural branch was tested)
+
+        [Fact]
+        public void AsTimeGenericUsesSingularDay()
+        {
+            long ms = Constants.MillisecondsInDay + 1500; // 1 day + 1.5 s
+            Assert.Equal("1 day, 1.5 s", ms.AsTime());
+        }
+
+        #endregion
+
+        #region Scale / FindMinMaxInOn / MaxIndex contracts
+
+        [Fact]
+        public void FindMinMaxInOnReturnsExtremes()
+        {
+            var (min, max) = new[] { 3.0, -1.0, 7.5, 2.0 }.FindMinMaxInOn();
+            Assert.Equal(-1.0, min);
+            Assert.Equal(7.5, max);
+        }
+
+        [Fact]
+        public void ScaleNormalizesToUnitRangeByDefault()
+        {
+            var result = new[] { 0.0, 5.0, 10.0 }.Scale().ToList();
+            Assert.Equal(0.0, result[0], Precision);
+            Assert.Equal(0.5, result[1], Precision);
+            Assert.Equal(1.0, result[2], Precision);
+        }
+
+        [Fact]
+        public void MaxIndexReturnsFirstOccurrenceOnTies()
+        {
+            // Documented contract: "If the sequence contains more than one, first occurrence's index will be returned."
+            Assert.Equal(1, new[] { 1.0, 9.0, 3.0, 9.0 }.MaxIndex());
+        }
+
+        #endregion
+
+        #region Breaking-change fixes (v12.0.0)
+
+        [Fact]
+        public void AreaReturnsNonNegativeForClockwiseWinding()
+        {
+            // Same unit square as the existing CCW test, listed clockwise: the magnitude is identical
+            // and a method named Area must never return a negative number.
+            var clockwise = new List<double[]>
+            {
+                new[] { 0.0, 0.0 },
+                new[] { 10.0, 0.0 },
+                new[] { 10.0, 10.0 },
+                new[] { 0.0, 10.0 },
+            };
+            Assert.Equal(100.0, clockwise.Area());
+        }
+
+        [Fact]
+        public void MaxIndexThrowsInvalidOperationOnEmptySequence()
+        {
+            // Matches LINQ Max()/Min() behaviour for empty sequences.
+            Assert.Throws<InvalidOperationException>(() => new List<double>().MaxIndex());
+        }
+
+        [Fact]
+        public void FindMinMaxInOnThrowsInvalidOperationOnEmptySequence()
+        {
+            Assert.Throws<InvalidOperationException>(() => new double[0].FindMinMaxInOn());
+        }
+
+        [Fact]
+        public void ScaleEmptySequenceReturnsEmpty()
+        {
+            // Scaling an empty sequence is a valid no-op and must keep returning empty, even though the
+            // underlying FindMinMaxInOn now rejects empty input.
+            Assert.Empty(new double[0].Scale((0.0, 1.0)));
+            Assert.Empty(new double[0].Scale());
+            Assert.Empty(new int[0].Scale((0.0, 1.0)));
+        }
+
+        #endregion
+    }
+}

--- a/Extensions.Standard/Extensions.Standard.csproj
+++ b/Extensions.Standard/Extensions.Standard.csproj
@@ -18,8 +18,12 @@ Suffixes (AsMemory, AsTime), Interpolate, Partition, Shuffle (O(n)), Softmax, In
     <RepositoryType>git</RepositoryType>
     <PackageTags>extensions, extension-methods, netcore, netstandard, boilerplate</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>11.0.0</Version>
-    <PackageReleaseNotes>DeepCopy is now a dependency-free reflection-based deep clone (copies private/inherited fields, preserves shared references and cycles, no serializable/parameterless-ctor requirement). Removed the Newtonsoft.Json dependency and the JsonSerializerSettings overload.</PackageReleaseNotes>
+    <Version>12.0.0</Version>
+    <PackageReleaseNotes>Breaking changes:
+- Area() now returns a non-negative magnitude (was the signed shoelace area, negative for clockwise polygons).
+- MaxIndex() and FindMinMaxInOn() now throw InvalidOperationException on an empty sequence (matching LINQ Max/Min). Scale() on an empty sequence still returns empty.
+- AsTime(TimeSpan) no longer leaves a trailing ", " separator and returns "0 ms" for TimeSpan.Zero (consistent with the AsTime(milliseconds) overload).
+- Removed the redundant Scale&lt;T&gt;(IEnumerable&lt;double&gt;) overload whose type parameter was unused (use the non-generic Scale()).</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Extensions.Standard/Utilities.cs
+++ b/Extensions.Standard/Utilities.cs
@@ -94,7 +94,7 @@ namespace Extensions.Standard
                 num += (polygon[index][0] + polygon[i][0]) * (polygon[index][1] - polygon[i][1]);
                 index = i;
             }
-            return num / 2;
+            return Math.Abs(num / 2);
         }
 
         #endregion
@@ -404,6 +404,8 @@ namespace Extensions.Standard
         public static int MaxIndex(this IEnumerable<double> input)
         {
             var inputAsList = input.ToList();
+            if (inputAsList.Count == 0)
+                throw new InvalidOperationException("Sequence contains no elements.");
             var index = 0;
             var value = inputAsList[0];
             for (var i = 0; i < inputAsList.Count; ++i)
@@ -639,7 +641,8 @@ namespace Extensions.Standard
             {
                 stb.AppendFormat("{0} ms", timeElapsed.Milliseconds);
             }
-            return stb.ToString();
+            var result = stb.ToString().TrimEnd(' ', ',');
+            return result.Length == 0 ? "0 ms" : result;
         }
 
         /// <summary>
@@ -775,17 +778,22 @@ namespace Extensions.Standard
         {
             var dataMin = double.MaxValue;
             var dataMax = double.MinValue;
+            var any = false;
             foreach (var item in data)
             {
+                any = true;
                 if (item < dataMin) dataMin = item;
                 if (item > dataMax) dataMax = item;
             }
+            if (!any)
+                throw new InvalidOperationException("Sequence contains no elements.");
             return (Min: dataMin, Max: dataMax);
         }
 
         public static IEnumerable<double> Scale(this IEnumerable<double> data, (double Min, double Max) scale)
         {
             var enumerated = data as double[] ?? data.ToArray();
+            if (enumerated.Length == 0) return Array.Empty<double>();
             var (min, max) = enumerated.FindMinMaxInOn();
             var m = (scale.Max - scale.Min) / (max - min);
             var c = scale.Min - min * m;
@@ -806,6 +814,7 @@ namespace Extensions.Standard
         public static IEnumerable<double> Scale<T>(this IEnumerable<T> data, (double Min, double Max) scale) where T : IConvertible
         {
             var enumerated = data as T[] ?? data.ToArray();
+            if (enumerated.Length == 0) return Array.Empty<double>();
             var (min, max) = enumerated.Select(x => Convert.ToDouble(x)).FindMinMaxInOn();
             var m = (scale.Max - scale.Min) / (max - min);
             var c = scale.Min - min * m;
@@ -816,11 +825,6 @@ namespace Extensions.Standard
                 result[i] = m * Convert.ToDouble(enumerated[i]) + c;
             }
             return result;
-        }
-
-        public static IEnumerable<double> Scale<T>(this IEnumerable<double> data) where T : IConvertible
-        {
-            return Scale(data, (Min: 0, Max: 1.0));
         }
 
         public static T Fit<T>(this T value, T min, T max) where T : IComparable<T>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Extensions.Standard
 
 [![CI](https://github.com/PFalkowski/Extensions.Standard/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/Extensions.Standard/actions/workflows/ci.yml)
-[![NuGet version (Extensions.Standard)](https://img.shields.io/nuget/v/Extensions.Standard.svg)](https://www.nuget.org/packages/Extensions.Standard/)
-[![Licence (Extensions.Serialization)](https://img.shields.io/github/license/mashape/apistatus.svg)](https://choosealicense.com/licenses/mit/)
+[![codecov](https://codecov.io/gh/PFalkowski/Extensions.Standard/branch/master/graph/badge.svg)](https://codecov.io/gh/PFalkowski/Extensions.Standard)
+[![NuGet version](https://img.shields.io/nuget/v/Extensions.Standard.svg)](https://www.nuget.org/packages/Extensions.Standard/)
+[![NuGet downloads](https://img.shields.io/nuget/dt/Extensions.Standard.svg)](https://www.nuget.org/packages/Extensions.Standard/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Lightweight extensions methods (and constants) for common programming tasks, like:
 

--- a/SONAR_SETUP.md
+++ b/SONAR_SETUP.md
@@ -1,0 +1,32 @@
+# SonarCloud setup (one-time)
+
+SonarCloud (now "SonarQube Cloud") is free for public repositories. The
+[`.github/workflows/sonar.yml`](.github/workflows/sonar.yml) workflow runs the analysis on every
+push/PR to `master`. It needs a one-time account setup plus a `SONAR_TOKEN` repository secret. Until
+the secret exists the workflow is a no-op (it logs a message and exits 0), so it will not turn CI red.
+
+## Steps
+
+1. Go to <https://sonarcloud.io> and **log in with GitHub**.
+2. **Analyze a new project** → choose the GitHub organization, then import
+   `PFalkowski/Extensions.Standard`.
+3. When prompted for the analysis method, pick **"With GitHub Actions"** (CI-based analysis —
+   required for C#; automatic analysis does not support C#).
+4. SonarCloud shows your **Organization Key** and **Project Key**. Confirm they match the values in
+   `sonar.yml`:
+   - `/o:` → Organization Key (the workflow assumes `pfalkowski`)
+   - `/k:` → Project Key (the workflow assumes `PFalkowski_Extensions.Standard`)
+
+   If SonarCloud generated different values, update those two lines in `sonar.yml`.
+5. SonarCloud generates a token. In GitHub: **Settings → Secrets and variables → Actions → New
+   repository secret**, name it `SONAR_TOKEN`, paste the value.
+6. (Recommended) In the SonarCloud project under **Administration → Analysis Method**, turn **off**
+   "Automatic Analysis" so it does not conflict with the CI-based analysis.
+
+## Notes
+
+- Coverage is collected with Microsoft's `dotnet-coverage` tool and handed to Sonar via
+  `sonar.cs.vscoveragexml.reportsPaths=coverage.xml`.
+- The scanner engine runs on Java 17, which the workflow installs.
+- A green PR badge / quality gate can be added to `README.md` once the project exists:
+  `[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_Extensions.Standard&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PFalkowski_Extensions.Standard)`


### PR DESCRIPTION
## Summary

A code-review pass over `master` plus the breaking-change fixes it surfaced, raising the package to **v12.0.0**. Also adds black-box test coverage for previously-untested methods and wires up Codecov + SonarCloud.

All work is test-driven: tests were written black-box (from each method's contract, not its body), which is what surfaced the four defects below. **228 tests pass** (195 original + 33 new); Release builds clean across `netstandard2.0` and `net8.0`.

## Breaking changes

| Change | Issue |
|--------|-------|
| `Area()` returns a non-negative magnitude (was the signed shoelace area — negative for clockwise polygons) | Closes #7 |
| Removed the redundant `Scale<T>(IEnumerable<double>)` overload with an unused type parameter (use non-generic `Scale()`) | Closes #8 |
| `MaxIndex()` / `FindMinMaxInOn()` throw `InvalidOperationException` on empty input (LINQ convention); `Scale(empty)` still returns empty | Closes #9 |
| `AsTime(TimeSpan)` drops the trailing `", "` separator and returns `"0 ms"` for `TimeSpan.Zero` | Closes #10 |

## Tooling & docs

- **Codecov**: CI collects coverage (`--collect:"XPlat Code Coverage"`) and uploads via `codecov-action@v5` (non-fatal). Added `coverlet.collector` to the test project.
- **SonarCloud**: new `.github/workflows/sonar.yml` + `SONAR_SETUP.md`. No-op until `SONAR_TOKEN` is set, so CI stays green.
- **README badges**: fixed NuGet version badge, added NuGet downloads + Codecov badges, replaced the broken placeholder license badge with a working MIT one.
- **CHANGELOG.md** added; version bumped `11.0.0` → `12.0.0` with `PackageReleaseNotes`.

## Follow-up (not in this PR)

- #11 — a repo admin must add the `SONAR_TOKEN` and `CODECOV_TOKEN` secrets for the badges/analysis to report live data. Left open intentionally.
- Publishing to NuGet is **not** triggered by this merge; it fires only on a `v*.*.*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)